### PR TITLE
add xz to required packages to install.packages("XML")

### DIFF
--- a/rtools40.md
+++ b/rtools40.md
@@ -66,7 +66,7 @@ An example is the old `XML` package. First install `libxml2` in rtools:
 
 ```sh
 # Run this in Rtools
-pacman -S mingw-w64-{i686,x86_64}-libxml2
+pacman -S mingw-w64-{i686,x86_64}-libxml2 mingw-w64-{i686,x86_64}-xz
 ```
 
 And then install `XML` like this:


### PR DESCRIPTION
I noticed that the documentation was not fully clear for the *Compiling R Packages with Custom Flags* section. It errored out with "could not find -llzma" on my machine. Installing the `xz` package fixes this. 

This PR purely updates the documentation. 